### PR TITLE
chore: release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.7](https://github.com/cxreiff/chainmail/releases/tag/v0.1.7) - 2025-06-08
+
+### Fixed
+
+- fixes
+- fixed some windowed mode issues
+
+### Other
+
+- name change to chainmailer
+- Create release_plz.yml
+- oops cargo lock
+- v0.1.6
+- v0.1.5
+- polish
+- v0.1.4
+- better sounds
+- info page, misc
+- v0.1.3
+- more game state logic, misc mechanics
+- v0.1.2
+- basic generation and loop
+- falling cubes, prompt
+- minor aesthetic changes
+- word position conversion
+- flying cubes
+- basic layout
+- v0.1.1
+- current letter display
+- initial commit

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1809,8 +1809,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chainmail"
-version = "0.1.6"
+name = "chainmailer"
+version = "0.1.7"
 dependencies = [
  "bevy",
  "bevy_asset_loader",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
-name = "chainmail"
-description = "If You Do Not Send This Letter To Ten Recipients You Will Be Visited By The Wraith"
+name = "chainmailer"
+description = "If You Do Not Send This Letter To Ten Recipients You Will Regret It"
 authors = ["cxreiff <cooper@cxreiff.com>"]
-version = "0.1.6"
+version = "0.1.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cxreiff/chainmail"

--- a/OUTLINE.md
+++ b/OUTLINE.md
@@ -1,6 +1,6 @@
-# Chainmail
+# chainmailer
 
-_If You Do Not Send This Letter To Ten Recipients You Will Be Visited By The Wraith_
+_If You Do Not Send This Letter To Ten Recipients You Will Regret It_
 
 ## Main Idea
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# Chainmail
+# chainmailer
 
-_If You Do Not Send This Letter To Ten Recipients You Will Be Visited By The Wraith_
+_If You Do Not Send This Letter To Ten Recipients You Will Regret It_
 
 [bevy game jam #6 submission](https://itch.io/jam/bevy-jam-6)


### PR DESCRIPTION



## 🤖 New release

* `chainmailer`: 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.7](https://github.com/cxreiff/chainmail/releases/tag/v0.1.7) - 2025-06-08

### Fixed

- fixes
- fixed some windowed mode issues

### Other

- name change to chainmailer
- Create release_plz.yml
- oops cargo lock
- v0.1.6
- v0.1.5
- polish
- v0.1.4
- better sounds
- info page, misc
- v0.1.3
- more game state logic, misc mechanics
- v0.1.2
- basic generation and loop
- falling cubes, prompt
- minor aesthetic changes
- word position conversion
- flying cubes
- basic layout
- v0.1.1
- current letter display
- initial commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).