### PR TITLE
chore: release v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.7](https://github.com/cxreiff/chainmail/releases/tag/v0.1.7) - 2025-06-08
+
+### Fixed
+
+- fixes
+- fixed some windowed mode issues
+
+### Other
+
+- name change to chainmailer
+- Create release_plz.yml
+- oops cargo lock
+- v0.1.6
+- v0.1.5
+- polish
+- v0.1.4
+- better sounds
+- info page, misc
+- v0.1.3
+- more game state logic, misc mechanics
+- v0.1.2
+- basic generation and loop
+- falling cubes, prompt
+- minor aesthetic changes
+- word position conversion
+- flying cubes
+- basic layout
+- v0.1.1
+- current letter display
+- initial commit


### PR DESCRIPTION



## 🤖 New release

* `chainmailer`: 0.1.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.7](https://github.com/cxreiff/chainmail/releases/tag/v0.1.7) - 2025-06-08

### Fixed

- fixes
- fixed some windowed mode issues

### Other

- name change to chainmailer
- Create release_plz.yml
- oops cargo lock
- v0.1.6
- v0.1.5
- polish
- v0.1.4
- better sounds
- info page, misc
- v0.1.3
- more game state logic, misc mechanics
- v0.1.2
- basic generation and loop
- falling cubes, prompt
- minor aesthetic changes
- word position conversion
- flying cubes
- basic layout
- v0.1.1
- current letter display
- initial commit
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).