### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/cxreiff/chainmailer/compare/v0.2.1...v0.2.2) - 2025-11-30
+
+### Other
+
+- bevy 0.17, bevy_ratatui 0.10, bevy_ratatui_camera 0.16
+
 ## [0.1.7](https://github.com/cxreiff/chainmail/releases/tag/v0.1.7) - 2025-06-08
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,7 +1995,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chainmailer"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bevy",
  "bevy_asset_loader",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "chainmailer"
 description = "If You Do Not Send This Letter To Ten Recipients You Will Regret It"
 authors = ["cxreiff <cooper@cxreiff.com>"]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/cxreiff/chainmail"


### PR DESCRIPTION



## 🤖 New release

* `chainmailer`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/cxreiff/chainmailer/compare/v0.2.1...v0.2.2) - 2025-11-30

### Other

- bevy 0.17, bevy_ratatui 0.10, bevy_ratatui_camera 0.16
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).